### PR TITLE
Add support for locally installed generator modules.

### DIFF
--- a/es5/lib/cli/stimpak.cli.js
+++ b/es5/lib/cli/stimpak.cli.js
@@ -5,9 +5,14 @@ var _fs = require("fs");
 
 var _fs2 = _interopRequireDefault(_fs);
 
+var _requireResolve = require("require-resolve");
+
+var _requireResolve2 = _interopRequireDefault(_requireResolve);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var Stimpak = require(__dirname + "/../stimpak/stimpak.js").default;
+
 
 var firstArgument = process.argv[2];
 
@@ -31,11 +36,17 @@ switch (firstArgument) {
 				var generatorName = argument;
 				var packageName = "stimpak-" + generatorName;
 
+				var packageInfo = (0, _requireResolve2.default)(packageName, process.cwd() + "/node_modules");
 				try {
-					var GeneratorConstructor = require(packageName).default;
+					var GeneratorConstructor = void 0;
+					if (packageInfo && packageInfo.src) {
+						GeneratorConstructor = require(packageInfo.src).default;
+					} else {
+						GeneratorConstructor = require(packageName).default;
+					}
 					stimpak.use(GeneratorConstructor);
 				} catch (error) {
-					var errorMessage = "\"" + generatorName + "\" is not installed. Use \"npm install stimpak-" + generatorName + " -g\"";
+					var errorMessage = "\"" + generatorName + "\" is not installed. Use \"npm install stimpak-" + generatorName + " -g\"\n";
 					process.stderr.write(errorMessage);
 				}
 			}

--- a/es5/spec/cli/stimpak.cli.answers.spec.js
+++ b/es5/spec/cli/stimpak.cli.answers.spec.js
@@ -1,65 +1,23 @@
 "use strict";
 
-var _fsExtra = require("fs-extra");
-
-var _fsExtra2 = _interopRequireDefault(_fsExtra);
-
-var _path = require("path");
-
-var _path2 = _interopRequireDefault(_path);
-
 var _child_process = require("child_process");
 
-var _temp = require("temp");
-
-var _temp2 = _interopRequireDefault(_temp);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var _stimpakCliHelper = require("./stimpak.cli.helper.js");
 
 describe("(CLI) stimpak --answers", function () {
 	var command = void 0,
-	    temporaryDirectoryPath = void 0;
+	    userProjectDirectoryPath = void 0;
 
 	beforeEach(function () {
-		temporaryDirectoryPath = _temp2.default.mkdirSync("stimpakgenerators");
-
-		var projectRootPath = _path2.default.normalize(__dirname + "/../../../");
-
-		var es5DirectoryPath = projectRootPath + "/es5";
-		var nodeModulesDirectoryPath = temporaryDirectoryPath + "/node_modules";
-		var nodeModulesFixtureDirectoryPath = es5DirectoryPath + "/spec/cli/fixtures/project/node_modules";
-		var stimpakDirectoryPath = nodeModulesDirectoryPath + "/stimpak";
-		var stimpakCliPath = stimpakDirectoryPath + "/es5/lib/cli/stimpak.cli.js";
-		var generatorOneDirectoryPath = stimpakDirectoryPath + "/node_modules/stimpak-test-1";
-		var generatorTwoDirectoryPath = stimpakDirectoryPath + "/node_modules/stimpak-test-2";
-		var generatorThreeDirectoryPath = stimpakDirectoryPath + "/node_modules/stimpak-test-3";
-
-		_fsExtra2.default.mkdirSync(nodeModulesDirectoryPath);
-
-		_fsExtra2.default.symlinkSync(projectRootPath, stimpakDirectoryPath);
-
-		try {
-			_fsExtra2.default.unlinkSync(generatorOneDirectoryPath);
-		} catch (error) {}
-		try {
-			_fsExtra2.default.unlinkSync(generatorTwoDirectoryPath);
-		} catch (error) {}
-		try {
-			_fsExtra2.default.unlinkSync(generatorThreeDirectoryPath);
-		} catch (error) {}
-
-		_fsExtra2.default.symlinkSync(nodeModulesFixtureDirectoryPath + "/stimpak-test-1", generatorOneDirectoryPath);
-
-		_fsExtra2.default.symlinkSync(nodeModulesFixtureDirectoryPath + "/stimpak-test-2", generatorTwoDirectoryPath);
-
-		_fsExtra2.default.symlinkSync(nodeModulesFixtureDirectoryPath + "/stimpak-test-3", generatorThreeDirectoryPath);
-
-		command = "node " + stimpakCliPath;
+		var options = (0, _stimpakCliHelper.setupCliEnvironment)();
+		command = options.command;
+		userProjectDirectoryPath = options.userProjectDirectoryPath;
 	});
 
 	it("should use provided answer and skip question prompt", function (done) {
 		command += " test-4";
-		(0, _child_process.exec)(command, function (error, stdout) {
+		(0, _child_process.exec)(command, { cwd: userProjectDirectoryPath }, function (error, stdout, stderr) {
+			stderr.should.eql("");
 			stdout.should.eql("");
 			done();
 		});

--- a/es5/spec/cli/stimpak.cli.generators.spec.js
+++ b/es5/spec/cli/stimpak.cli.generators.spec.js
@@ -10,55 +10,18 @@ var _path2 = _interopRequireDefault(_path);
 
 var _child_process = require("child_process");
 
-var _temp = require("temp");
-
-var _temp2 = _interopRequireDefault(_temp);
-
-var _glob = require("glob");
-
-var _glob2 = _interopRequireDefault(_glob);
+var _stimpakCliHelper = require("./stimpak.cli.helper.js");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 describe("(CLI) stimpak generators", function () {
 	var command = void 0,
-	    temporaryDirectoryPath = void 0;
+	    userProjectDirectoryPath = void 0;
 
 	beforeEach(function () {
-		temporaryDirectoryPath = _temp2.default.mkdirSync("stimpakgenerators");
-
-		var projectRootPath = _path2.default.normalize(__dirname + "/../../../");
-
-		var es5DirectoryPath = projectRootPath + "/es5";
-		var nodeModulesDirectoryPath = temporaryDirectoryPath + "/node_modules";
-		var nodeModulesFixtureDirectoryPath = es5DirectoryPath + "/spec/cli/fixtures/project/node_modules";
-		var stimpakDirectoryPath = nodeModulesDirectoryPath + "/stimpak";
-		var stimpakCliPath = stimpakDirectoryPath + "/es5/lib/cli/stimpak.cli.js";
-		var generatorOneDirectoryPath = stimpakDirectoryPath + "/node_modules/stimpak-test-1";
-		var generatorTwoDirectoryPath = stimpakDirectoryPath + "/node_modules/stimpak-test-2";
-		var generatorThreeDirectoryPath = stimpakDirectoryPath + "/node_modules/stimpak-test-3";
-
-		_fsExtra2.default.mkdirSync(nodeModulesDirectoryPath);
-
-		_fsExtra2.default.symlinkSync(projectRootPath, stimpakDirectoryPath);
-
-		try {
-			_fsExtra2.default.unlinkSync(generatorOneDirectoryPath);
-		} catch (error) {}
-		try {
-			_fsExtra2.default.unlinkSync(generatorTwoDirectoryPath);
-		} catch (error) {}
-		try {
-			_fsExtra2.default.unlinkSync(generatorThreeDirectoryPath);
-		} catch (error) {}
-
-		_fsExtra2.default.symlinkSync(nodeModulesFixtureDirectoryPath + "/stimpak-test-1", generatorOneDirectoryPath);
-
-		_fsExtra2.default.symlinkSync(nodeModulesFixtureDirectoryPath + "/stimpak-test-2", generatorTwoDirectoryPath);
-
-		_fsExtra2.default.symlinkSync(nodeModulesFixtureDirectoryPath + "/stimpak-test-3", generatorThreeDirectoryPath);
-
-		command = "node " + stimpakCliPath;
+		var options = (0, _stimpakCliHelper.setupCliEnvironment)();
+		command = options.command;
+		userProjectDirectoryPath = options.userProjectDirectoryPath;
 	});
 
 	it("should throw an error if any of the generators aren't installed", function (done) {
@@ -66,7 +29,7 @@ describe("(CLI) stimpak generators", function () {
 		command += " " + invalidGeneratorName;
 
 		(0, _child_process.exec)(command, function (error, stdout, stderr) {
-			var expectedStderr = "\"" + invalidGeneratorName + "\" is not installed. Use \"npm install stimpak-" + invalidGeneratorName + " -g\"";
+			var expectedStderr = "\"" + invalidGeneratorName + "\" is not installed. Use \"npm install stimpak-" + invalidGeneratorName + " -g\"\n";
 			stderr.should.eql(expectedStderr);
 			done();
 		});
@@ -74,9 +37,9 @@ describe("(CLI) stimpak generators", function () {
 
 	it("should use the current working directory as the destination", function (done) {
 		command += " test-1";
-		var expectedFilePath = temporaryDirectoryPath + "/generated1.js";
+		var expectedFilePath = userProjectDirectoryPath + "/generated1.js";
 
-		(0, _child_process.exec)(command, { cwd: temporaryDirectoryPath }, function (error) {
+		(0, _child_process.exec)(command, { cwd: userProjectDirectoryPath }, function (error) {
 			_fsExtra2.default.existsSync(expectedFilePath).should.be.true;
 			done(error);
 		});
@@ -89,7 +52,7 @@ describe("(CLI) stimpak generators", function () {
 
 		var expectedStdout = _fsExtra2.default.readFileSync(doneFileTemplatePath, { encoding: "utf-8" });
 
-		(0, _child_process.exec)(command, { cwd: temporaryDirectoryPath }, function (error, stdout) {
+		(0, _child_process.exec)(command, { cwd: userProjectDirectoryPath }, function (error, stdout) {
 			stdout.should.eql(expectedStdout);
 			done(error);
 		});
@@ -98,9 +61,9 @@ describe("(CLI) stimpak generators", function () {
 	it("should run multiple designated generators", function (done) {
 		command += " test-1 test-2";
 
-		var expectedFilePath = temporaryDirectoryPath + "/generated2.js";
+		var expectedFilePath = userProjectDirectoryPath + "/generated2.js";
 
-		(0, _child_process.exec)(command, { cwd: temporaryDirectoryPath }, function (error) {
+		(0, _child_process.exec)(command, { cwd: userProjectDirectoryPath }, function (error) {
 			_fsExtra2.default.existsSync(expectedFilePath).should.be.true;
 			done(error);
 		});
@@ -109,7 +72,7 @@ describe("(CLI) stimpak generators", function () {
 	it("should throw an error returned by .generate", function (done) {
 		command += " test-3";
 
-		(0, _child_process.exec)(command, { cwd: temporaryDirectoryPath }, function (error) {
+		(0, _child_process.exec)(command, { cwd: userProjectDirectoryPath }, function (error) {
 			error.message.should.contain("Generator 3 Error!");
 			done();
 		});

--- a/es5/spec/cli/stimpak.cli.helper.js
+++ b/es5/spec/cli/stimpak.cli.helper.js
@@ -1,0 +1,80 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.setupCliEnvironment = setupCliEnvironment;
+
+var _fsExtra = require("fs-extra");
+
+var _fsExtra2 = _interopRequireDefault(_fsExtra);
+
+var _path = require("path");
+
+var _path2 = _interopRequireDefault(_path);
+
+var _temp = require("temp");
+
+var _temp2 = _interopRequireDefault(_temp);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function setupCliEnvironment() {
+  var temporaryDirectoryPath = _temp2.default.mkdirSync("stimpakgenerators");
+
+  var projectRootPath = _path2.default.normalize(__dirname + "/../../../");
+
+  var es5DirectoryPath = projectRootPath + "/es5";
+  var nodeModulesFixtureDirectoryPath = es5DirectoryPath + "/spec/cli/fixtures/project/node_modules";
+
+  var generatorOneDirectoryPath = nodeModulesFixtureDirectoryPath + "/stimpak-test-1";
+  var generatorTwoDirectoryPath = nodeModulesFixtureDirectoryPath + "/stimpak-test-2";
+  var generatorThreeDirectoryPath = nodeModulesFixtureDirectoryPath + "/stimpak-test-3";
+  var generatorFourDirectoryPath = nodeModulesFixtureDirectoryPath + "/stimpak-test-4";
+
+  var pseudoGlobalNodeModulesDirectoryPath = temporaryDirectoryPath + "/node_modules";
+  var userProjectDirectoryPath = temporaryDirectoryPath + "/user_project";
+  var pseudoLocalNodeModulesDirectoryPath = userProjectDirectoryPath + "/node_modules";
+
+  var stimpakCliPath = pseudoGlobalNodeModulesDirectoryPath + "/stimpak/es5/lib/cli/stimpak.cli.js";
+
+  _fsExtra2.default.mkdirSync(pseudoGlobalNodeModulesDirectoryPath);
+  _fsExtra2.default.mkdirSync(userProjectDirectoryPath);
+  _fsExtra2.default.mkdirSync(pseudoLocalNodeModulesDirectoryPath);
+
+  var pseudoNpmInstall = function pseudoNpmInstall(srcDirectoryPath, dstDirectoryPath) {
+    try {
+      _fsExtra2.default.unlinkSync(dstDirectoryPath);
+    } catch (ex) {
+      // nop
+    }
+    _fsExtra2.default.symlinkSync(srcDirectoryPath, dstDirectoryPath);
+  };
+
+  var pseudoNpmInstallGlobally = function pseudoNpmInstallGlobally(srcDirectoryPath, moduleName) {
+    pseudoNpmInstall(srcDirectoryPath, pseudoGlobalNodeModulesDirectoryPath + "/" + moduleName);
+  };
+
+  var pseudoNpmInstallLocally = function pseudoNpmInstallLocally(srcDirectoryPath, moduleName) {
+    pseudoNpmInstall(srcDirectoryPath, pseudoLocalNodeModulesDirectoryPath + "/" + moduleName);
+  };
+
+  // simulate "npm install ..."
+  pseudoNpmInstallGlobally(projectRootPath, 'stimpak');
+  pseudoNpmInstallGlobally(generatorOneDirectoryPath, 'stimpak-test-1');
+  pseudoNpmInstallLocally(generatorTwoDirectoryPath, 'stimpak-test-2');
+  pseudoNpmInstallGlobally(generatorThreeDirectoryPath, 'stimpak-test-3');
+  pseudoNpmInstallGlobally(generatorFourDirectoryPath, 'stimpak-test-4');
+
+  var command = "node " + stimpakCliPath;
+
+  console.log("cd " + userProjectDirectoryPath + " && node " + stimpakCliPath);
+
+  return {
+    temporaryDirectoryPath: temporaryDirectoryPath,
+    userProjectDirectoryPath: userProjectDirectoryPath,
+    pseudoNpmInstallGlobally: pseudoNpmInstallGlobally,
+    pseudoNpmInstallLocally: pseudoNpmInstallLocally,
+    command: command
+  };
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./es5/lib/index.js",
   "bin": {
     "stimpak": "./es5/lib/cli/stimpak.cli.js",
-		"sptester": "./es5/lib/cli/tester.cli.js"
+    "sptester": "./es5/lib/cli/tester.cli.js"
   },
   "scripts": {
     "test": "gulp test"
@@ -50,12 +50,17 @@
     "suppose": "^0.5.2"
   },
   "dependencies": {
+    "flowsync": "^0.1.12",
     "fs-extra": "^0.30.0",
+    "glob": "^7.0.3",
+    "incognito": "^0.1.4",
     "inquirer": "^1.0.2",
     "lodash.template": "^4.2.4",
     "mrt": "^0.1.5",
     "promptly": "^1.1.0",
+    "require-resolve": "0.0.2",
     "staircase": "^0.1.0",
+    "temp": "^0.8.3",
     "vinyl": "^1.1.1"
   }
 }

--- a/source/lib/cli/stimpak.cli.js
+++ b/source/lib/cli/stimpak.cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fileSystem from "fs";
 const Stimpak = require(__dirname + "/../stimpak/stimpak.js").default;
+import requireResolve from "require-resolve";
 
 const firstArgument = process.argv[2];
 
@@ -27,11 +28,17 @@ switch (firstArgument) {
 				const generatorName = argument;
 				const packageName = `stimpak-${generatorName}`;
 
+				const packageInfo = requireResolve(packageName, `${process.cwd()}/node_modules`);
 				try {
-					const GeneratorConstructor = require(packageName).default;
+					let GeneratorConstructor;
+					if (packageInfo && packageInfo.src) {
+						GeneratorConstructor = require(packageInfo.src).default;
+					} else {
+						GeneratorConstructor = require(packageName).default;
+					}
 					stimpak.use(GeneratorConstructor);
 				} catch (error) {
-					const errorMessage = `"${generatorName}" is not installed. Use "npm install stimpak-${generatorName} -g"`;
+					const errorMessage = `"${generatorName}" is not installed. Use "npm install stimpak-${generatorName} -g"\n`;
 					process.stderr.write(errorMessage);
 				}
 			}

--- a/source/spec/cli/stimpak.cli.answers.spec.js
+++ b/source/spec/cli/stimpak.cli.answers.spec.js
@@ -1,74 +1,20 @@
-import fileSystem from "fs-extra";
-import path from "path";
 import { exec as runCommand } from "child_process";
-import temp from "temp";
+import { setupCliEnvironment } from "./stimpak.cli.helper.js";
 
 describe("(CLI) stimpak --answers", () => {
 	let command,
-			temporaryDirectoryPath;
+	    userProjectDirectoryPath;
 
 	beforeEach(() => {
-		temporaryDirectoryPath = temp.mkdirSync("stimpakgenerators");
-
-		const projectRootPath = path.normalize(
-			`${__dirname}/../../../`
-		);
-
-		const es5DirectoryPath =
-			`${projectRootPath}/es5`;
-		const nodeModulesDirectoryPath =
-			`${temporaryDirectoryPath}/node_modules`;
-		const nodeModulesFixtureDirectoryPath =
-			`${es5DirectoryPath}/spec/cli/fixtures/project/node_modules`;
-		const stimpakDirectoryPath =
-			`${nodeModulesDirectoryPath}/stimpak`;
-		const stimpakCliPath =
-			`${stimpakDirectoryPath}/es5/lib/cli/stimpak.cli.js`;
-		const generatorOneDirectoryPath =
-			`${stimpakDirectoryPath}/node_modules/stimpak-test-1`;
-		const generatorTwoDirectoryPath =
-			`${stimpakDirectoryPath}/node_modules/stimpak-test-2`;
-		const generatorThreeDirectoryPath =
-			`${stimpakDirectoryPath}/node_modules/stimpak-test-3`;
-
-		fileSystem.mkdirSync(nodeModulesDirectoryPath);
-
-		fileSystem.symlinkSync(
-			projectRootPath,
-			stimpakDirectoryPath
-		);
-
-		try {
-			fileSystem.unlinkSync(generatorOneDirectoryPath);
-		}	catch (error) {}
-		try {
-			fileSystem.unlinkSync(generatorTwoDirectoryPath);
-		}	catch (error) {}
-		try {
-			fileSystem.unlinkSync(generatorThreeDirectoryPath);
-		}	catch (error) {}
-
-		fileSystem.symlinkSync(
-			`${nodeModulesFixtureDirectoryPath}/stimpak-test-1`,
-			generatorOneDirectoryPath
-		);
-
-		fileSystem.symlinkSync(
-			`${nodeModulesFixtureDirectoryPath}/stimpak-test-2`,
-			generatorTwoDirectoryPath
-		);
-
-		fileSystem.symlinkSync(
-			`${nodeModulesFixtureDirectoryPath}/stimpak-test-3`,
-			generatorThreeDirectoryPath
-		);
-
-		command = `node ${stimpakCliPath}`;
+		const options = setupCliEnvironment();
+		command = options.command;
+		userProjectDirectoryPath = options.userProjectDirectoryPath;
 	});
 
 	it("should use provided answer and skip question prompt", done => {
 		command += " test-4";
-		runCommand(command, (error, stdout) => {
+		runCommand(command, { cwd: userProjectDirectoryPath }, (error, stdout, stderr) => {
+			stderr.should.eql("");
 			stdout.should.eql("");
 			done();
 		});

--- a/source/spec/cli/stimpak.cli.helper.js
+++ b/source/spec/cli/stimpak.cli.helper.js
@@ -1,0 +1,73 @@
+import fileSystem from "fs-extra";
+import path from "path";
+import temp from "temp";
+
+export function setupCliEnvironment() {
+  const temporaryDirectoryPath = temp.mkdirSync("stimpakgenerators");
+
+  const projectRootPath = path.normalize(
+    `${__dirname}/../../../`
+  );
+
+  const es5DirectoryPath =
+    `${projectRootPath}/es5`;
+  const nodeModulesFixtureDirectoryPath =
+    `${es5DirectoryPath}/spec/cli/fixtures/project/node_modules`;
+
+  const generatorOneDirectoryPath =
+    `${nodeModulesFixtureDirectoryPath}/stimpak-test-1`;
+  const generatorTwoDirectoryPath =
+    `${nodeModulesFixtureDirectoryPath}/stimpak-test-2`;
+  const generatorThreeDirectoryPath =
+    `${nodeModulesFixtureDirectoryPath}/stimpak-test-3`;
+  const generatorFourDirectoryPath =
+    `${nodeModulesFixtureDirectoryPath}/stimpak-test-4`;
+
+  const pseudoGlobalNodeModulesDirectoryPath =
+    `${temporaryDirectoryPath}/node_modules`;
+  const userProjectDirectoryPath =
+    `${temporaryDirectoryPath}/user_project`;
+  const pseudoLocalNodeModulesDirectoryPath =
+    `${userProjectDirectoryPath}/node_modules`;
+
+  const stimpakCliPath =
+    `${pseudoGlobalNodeModulesDirectoryPath}/stimpak/es5/lib/cli/stimpak.cli.js`;
+
+  fileSystem.mkdirSync(pseudoGlobalNodeModulesDirectoryPath);
+  fileSystem.mkdirSync(userProjectDirectoryPath);
+  fileSystem.mkdirSync(pseudoLocalNodeModulesDirectoryPath);
+
+  const pseudoNpmInstall = (srcDirectoryPath, dstDirectoryPath) => {
+    try {
+      fileSystem.unlinkSync(dstDirectoryPath);
+    } catch (ex) {
+      // nop
+    }
+    fileSystem.symlinkSync(srcDirectoryPath, dstDirectoryPath);
+  };
+
+  const pseudoNpmInstallGlobally = (srcDirectoryPath, moduleName) => {
+    pseudoNpmInstall(srcDirectoryPath, `${pseudoGlobalNodeModulesDirectoryPath}/${moduleName}`);
+  };
+
+  const pseudoNpmInstallLocally = (srcDirectoryPath, moduleName) => {
+    pseudoNpmInstall(srcDirectoryPath, `${pseudoLocalNodeModulesDirectoryPath}/${moduleName}`);
+  };
+
+  // simulate "npm install ..."
+  pseudoNpmInstallGlobally(projectRootPath, 'stimpak');
+  pseudoNpmInstallGlobally(generatorOneDirectoryPath, 'stimpak-test-1');
+  pseudoNpmInstallLocally(generatorTwoDirectoryPath, 'stimpak-test-2');
+  pseudoNpmInstallGlobally(generatorThreeDirectoryPath, 'stimpak-test-3');
+  pseudoNpmInstallGlobally(generatorFourDirectoryPath, 'stimpak-test-4');
+
+  const command = `node ${stimpakCliPath}`;
+
+  return {
+    temporaryDirectoryPath,
+    userProjectDirectoryPath,
+    pseudoNpmInstallGlobally,
+    pseudoNpmInstallLocally,
+    command,
+  };
+}


### PR DESCRIPTION
This commit extends the CLI generator module search functionality
to also look in the current working directory. That way users
of stimpak can install the generator locally before running
the stimpak CLI.

It also refactors the CLI spec setup (creating directories and
symlinks) into a separate helper module to be able to use it in
different specs.

The factored out CLI spec setup uses a slightly different directory
layout. Previously the test only passed, because the test generators
where symlinked into "((stimpak-path))/node_modules/stimpak-test-((x))"
which is most probably not the case on end-user systems. The
refactored CLI spec setup "simulates" installing "stimpak" and some
test generators pseudo-globally  and some test generators locally to
the end user project directory.
