### PR TITLE
doc(fix): removed parseInt(<string>) => NaN

### DIFF
--- a/API.md
+++ b/API.md
@@ -680,13 +680,11 @@ stimpak
 .answers({
 	something: "1",
 	blah: "2",
-	Bob: "Belcher"
 });
 
 stimpak.answers().should.eql({
 	something: 1,
 	blah: 2,
-	Bob: "Belcher"
 });
 ```
 


### PR DESCRIPTION
If you `parseInt("Belcher")`, you will get `NaN`, not `"Belcher"`.
